### PR TITLE
Proposal: Adaption of the forward/reverse search behavior for custom source files instead of *.tex

### DIFF
--- a/de.vonloesch.pdf4eclipse/META-INF/MANIFEST.MF
+++ b/de.vonloesch.pdf4eclipse/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Bundle-ClassPath: .,
  lib/jbig2.jar,
  lib/PDFrenderer.jar
 Bundle-Vendor: %Bundle-Vendor
+Export-Package: de.vonloesch.synctex

--- a/de.vonloesch.pdf4eclipse/build.properties
+++ b/de.vonloesch.pdf4eclipse/build.properties
@@ -5,5 +5,6 @@ bin.includes = plugin.xml,\
                .,\
                icons/,\
                lib/,\
-               OSGI-INF/l10n/bundle.properties
+               OSGI-INF/l10n/bundle.properties,\
+               schema/
 

--- a/de.vonloesch.pdf4eclipse/plugin.xml
+++ b/de.vonloesch.pdf4eclipse/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension-point id="de.vonloesch.pdf4Eclipse.synctexParserAdapter" name="SynctexParserAdapter" schema="schema/de.vonloesch.pdf4Eclipse.synctexParser.exsd"/>
+   <extension-point id="de.vonloesch.pdf4Eclipse.synctexParserAdapter" name="SynctexParserAdapter" schema="schema/de.vonloesch.pdf4Eclipse.synctexParserAdapter.exsd"/>
 
    <extension
          point="org.eclipse.ui.editors">

--- a/de.vonloesch.pdf4eclipse/plugin.xml
+++ b/de.vonloesch.pdf4eclipse/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
+   <extension-point id="de.vonloesch.pdf4Eclipse.synctexParserAdapter" name="SynctexParserAdapter" schema="schema/de.vonloesch.pdf4Eclipse.synctexParser.exsd"/>
 
    <extension
          point="org.eclipse.ui.editors">

--- a/de.vonloesch.pdf4eclipse/schema/de.vonloesch.pdf4Eclipse.synctexParserAdapter.exsd
+++ b/de.vonloesch.pdf4eclipse/schema/de.vonloesch.pdf4Eclipse.synctexParserAdapter.exsd
@@ -1,0 +1,112 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="de.vonloesch.pdf4Eclipse" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="de.vonloesch.pdf4Eclipse" id="de.vonloesch.pdf4Eclipse.synctexParserAdapter" name="SynctexParserAdapter"/>
+      </appinfo>
+      <documentation>
+         SynctexParserAdapter provides an extension to register an adapter to manipulate the SyncTex file resolution.
+This could be used the change the file which will open/is open by the PDF-Viewer.
+
+This is especially helpful, when the used .tex files are generated from other files and the editor shall display the source files.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="adapterFactory"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="adapterFactory">
+      <complexType>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":de.vonloesch.synctex.ISynctexParserAdapterFactory"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/de.vonloesch.pdf4eclipse/src/de/vonloesch/pdf4eclipse/editors/PDFEditor.java
+++ b/de.vonloesch.pdf4eclipse/src/de/vonloesch/pdf4eclipse/editors/PDFEditor.java
@@ -27,6 +27,7 @@ import java.util.zip.GZIPInputStream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
@@ -128,6 +129,7 @@ public class PDFEditor extends EditorPart implements IResourceChangeListener,
 
 	private Cursor cursorHand;
 	private Cursor cursorArrow;
+    private IProject eclipseProject;
 	
 	public PDFEditor() {
 		super();
@@ -177,7 +179,9 @@ public class PDFEditor extends EditorPart implements IResourceChangeListener,
 			file = new File(((FileStoreEditorInput)input).getURI());
 		}
 		else if ((input instanceof IFileEditorInput)) {
-			file = new File(((IFileEditorInput) input).getFile().getLocationURI());
+			IFileEditorInput eclipseInputFile = (IFileEditorInput) input;
+            file = new File(eclipseInputFile.getFile().getLocationURI());
+            eclipseProject = eclipseInputFile.getFile().getProject();
 		}
 		else {
 			throw new PartInitException(Messages.PDFEditor_ErrorMsg1);
@@ -553,7 +557,7 @@ public class PDFEditor extends EditorPart implements IResourceChangeListener,
 		try {
 			//FIXME: Create a job for this
 			ISynctexParser p = createSimpleSynctexParser(syncTeXFile);
-			//System.out.println("Start Forward search");
+			p.setEclipseProject(eclipseProject);
 			p.setForwardSearchInformation(file, lineNr);
 			p.startForward();
 			p.close();

--- a/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/DefaultSynctexParserFactory.java
+++ b/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/DefaultSynctexParserFactory.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Boris von Loesch.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Andreas Turban - initial API and implementation
+ ******************************************************************************/
+package de.vonloesch.synctex;
+
+import java.io.BufferedReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.Platform;
+
+/**
+ * Factory to create {@link ISynctexParser} instances and wrap them with
+ * contributed adapters of the {@link ISynctexParser}, with
+ * {@link ISynctexParserAdapterFactory}.
+ * 
+ * <p>
+ * The {@link ISynctexParserAdapterFactory} instances are contributed via an
+ * eclipse extension point.
+ * </p>
+ * 
+ * @author Andreas Turban
+ *
+ */
+public class DefaultSynctexParserFactory {
+
+	private static final String EXT_ID = "de.vonloesch.pdf4Eclipse.synctexParserAdapter";
+
+	private static final List<ISynctexParserAdapterFactory> adapters;
+
+	static {
+		ArrayList<ISynctexParserAdapterFactory> adaptersLoc = new ArrayList<ISynctexParserAdapterFactory>();
+		IConfigurationElement[] configurationElements = Platform.getExtensionRegistry()
+				.getConfigurationElementsFor(EXT_ID);
+		for (IConfigurationElement elem : configurationElements) {
+			try {
+				Object obj = elem.createExecutableExtension("class");
+				if (obj instanceof ISynctexParserAdapterFactory) {
+					adaptersLoc.add((ISynctexParserAdapterFactory) obj);
+				}
+			} catch (CoreException e) {
+				// Ignore wrong contributed adapter
+			}
+		}
+		adaptersLoc.trimToSize();
+		adapters = Collections.unmodifiableList(adaptersLoc);
+	}
+
+	public static ISynctexParser create(BufferedReader r) {
+		ISynctexParser parser = new SimpleSynctexParser(r);
+		for (ISynctexParserAdapterFactory factory : adapters) {
+			parser = factory.createAdapter(parser);
+		}
+		return parser;
+	}
+
+}

--- a/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/ISynctexParser.java
+++ b/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/ISynctexParser.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Boris von Loesch.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Andreas Turban - initial API
+ ******************************************************************************/
+package de.vonloesch.synctex;
+
+import java.io.IOException;
+
+/**
+ * {@link ISynctexParser} defines the API for the Synctex search feature.
+ * 
+ * @author Andreas Turban
+ * @author Boris von Loesch
+ * @see DefaultSynctexParserFactory
+ */
+public interface ISynctexParser {
+
+	void setReverseSearchInformation(int currentPage, double pdfX, double pdfY);
+
+	void startReverse() throws IOException;
+
+	void startForward() throws IOException;
+
+	void close() throws IOException;
+
+	String getSourceFilePath();
+
+	int getSourceLineNr();
+
+	void setForwardSearchInformation(String file, int lineNr);
+
+	double[] getForwardSearchResult();
+
+}

--- a/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/ISynctexParser.java
+++ b/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/ISynctexParser.java
@@ -12,6 +12,8 @@ package de.vonloesch.synctex;
 
 import java.io.IOException;
 
+import org.eclipse.core.resources.IProject;
+
 /**
  * {@link ISynctexParser} defines the API for the Synctex search feature.
  * 
@@ -21,20 +23,22 @@ import java.io.IOException;
  */
 public interface ISynctexParser {
 
-	void setReverseSearchInformation(int currentPage, double pdfX, double pdfY);
+    void setReverseSearchInformation(int currentPage, double pdfX, double pdfY);
 
-	void startReverse() throws IOException;
+    void startReverse() throws IOException;
 
-	void startForward() throws IOException;
+    void startForward() throws IOException;
 
-	void close() throws IOException;
+    void close() throws IOException;
 
-	String getSourceFilePath();
+    String getSourceFilePath();
 
-	int getSourceLineNr();
+    int getSourceLineNr();
 
-	void setForwardSearchInformation(String file, int lineNr);
+    void setForwardSearchInformation(String file, int lineNr);
 
-	double[] getForwardSearchResult();
+    double[] getForwardSearchResult();
+
+    void setEclipseProject(IProject eclipseProject);
 
 }

--- a/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/ISynctexParserAdapterFactory.java
+++ b/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/ISynctexParserAdapterFactory.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Boris von Loesch.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Andreas Turban - initial API and implementation
+ ******************************************************************************/
+package de.vonloesch.synctex;
+
+
+/**
+ * {@link ISynctexParserAdapterFactory} wraps an passed {@link ISynctexParser} with an adapter to change the forward and reverse search behavior.
+ * contributed adapters of the {@link ISynctexParser}, with
+ * {@link ISynctexParserAdapterFactory}.
+ * 
+ * <p>
+ * The {@link ISynctexParserAdapterFactory} instances are contributed via the 
+ * eclipse extension point "de.vonloesch.pdf4Eclipse.synctexParserAdapter".
+ * </p>
+ * 
+ * @author Andreas Turban
+ *
+ */
+public interface ISynctexParserAdapterFactory {
+
+	/**
+	 * Shall wrap the passed {@link ISynctexParser} to adapt the forward and reverse search behavior.
+	 */
+	ISynctexParser createAdapter(ISynctexParser parser);
+}

--- a/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/SimpleSynctexParser.java
+++ b/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/SimpleSynctexParser.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Stack;
 import java.util.TreeMap;
 
+import org.eclipse.core.resources.IProject;
+
 /**
  * A simple parser for SyncTeX files. Allows forward and reverse search.
  * More information about SyncTeX and the official C-implementation can be found
@@ -83,7 +85,17 @@ class SimpleSynctexParser implements ISynctexParser {
 		dist = Double.MAX_VALUE;
 	}
 	
+	
+	
 	/**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEclipseProject(IProject eclipseProject) {
+        
+    }
+
+    /**
 	 * Closes the SimpleSynctexParser and releases any
 	 * system resources  associated with it.
 	 * Once the stream has been closed, further 

--- a/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/SimpleSynctexParser.java
+++ b/de.vonloesch.pdf4eclipse/src/de/vonloesch/synctex/SimpleSynctexParser.java
@@ -7,6 +7,7 @@
  * 
  * Contributors:
  *     Boris von Loesch - initial API and implementation
+ *     Andreas Turban   - Added interface ISynctexParser
  ******************************************************************************/
 package de.vonloesch.synctex;
 
@@ -28,7 +29,7 @@ import java.util.TreeMap;
  * @author Boris von Loesch
  *
  */
-public class SimpleSynctexParser {
+class SimpleSynctexParser implements ISynctexParser {
 	public static final int SEARCH_FORWARD = 1;
 	public static final int SEARCH_REVERSE = 2;
 	
@@ -43,8 +44,8 @@ public class SimpleSynctexParser {
 	Map<Integer, String> fileMap;
 		
 	//Forward search information
-	public String sourceFilePath;
-	public int sourceLineNr;
+	private String sourceFilePath;
+	private int sourceLineNr;
 
 	//helper (forward search)
 	private int smallerLineNr;
@@ -464,5 +465,15 @@ public class SimpleSynctexParser {
 		if (endPos < 0) endPos = line.length();
 		nextPos = endPos;
 		return line.substring(pos + 1, endPos);
+	}
+
+	@Override
+	public String getSourceFilePath() {
+	return sourceFilePath;
+	}
+
+	@Override
+	public int getSourceLineNr() {
+		return sourceLineNr;
 	}
 }


### PR DESCRIPTION
Hello,
I would like to change the forward/reverse search behavior of SimpleSynctexParser by an SynctexParserAdapter, from another eclipse plugin.

The use case is, I generate *.tex files from other files like *.java, *.groovy, *.scala and *.md.
The generated tex files are not much help to jump to. So it would be great to jump directly to the real source instead of the generated *.tex file.

The SynctexParserAdapter allows me to modify the lookup of the PDF target or the source file to jump between e.g. *.java and the PDF file.

The adapter will implement the ISynctexParser methods and change the returned file paths, if the adapter find a corresonding java file.

The SimpleSynctexParser was not changed, i only "intercept" the method calls by the adapter.

The extension point is used to scan for adapters in the EclipseIDE, so that your plugin do not have to implement my custom logic.

This only **a proposal**, please comment on my idea and let me know what you think about it.
I would be pleased to help to integrate the feature.
Andreas Turban
